### PR TITLE
fix: GitHub Pages workflow build failure - use docs folder instead of content

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,9 +4,9 @@ on:
   push:
     branches: [main]
     paths:
-      - "content/**"
+      - "docs/**"
       - "themes/**"
-      - "hugo.toml"
+      - "config/_default/hugo.toml"
       - "layouts/**"
       - "static/**"
       - "assets/**"
@@ -55,19 +55,19 @@ jobs:
       - name: Verify content structure
         run: |
           echo "🔍 Verifying content structure..."
-          if [ ! -d "content" ]; then
-            echo "❌ Content directory not found"
+          if [ ! -d "docs" ]; then
+            echo "❌ Docs directory not found"
             exit 1
           fi
 
-          if [ ! -f "content/_index.md" ]; then
+          if [ ! -f "docs/_index.md" ]; then
             echo "❌ Homepage content not found"
             exit 1
           fi
 
           echo "✅ Content structure verified"
-          echo "📁 Content files:"
-          ls -la content/
+          echo "📁 Docs files:"
+          ls -la docs/
 
       - name: Install Task
         run: |
@@ -84,7 +84,7 @@ jobs:
 
       - name: Generate CLI documentation
         run: |
-          mkdir -p content/cli-reference
+          mkdir -p docs/cli-reference
 
           # Try to generate real CLI docs first
           if [ -f "./build/dev-stack" ] && ./build/dev-stack --help > /tmp/cli-help.txt 2>&1; then
@@ -101,7 +101,7 @@ jobs:
               echo '```'
               cat /tmp/cli-help.txt
               echo '```'
-            } > content/cli-reference/index.md
+            } > docs/cli-reference/index.md
             echo "✅ CLI documentation generated from binary"
           else
             echo "🔍 Creating CLI reference placeholder..."
@@ -117,7 +117,7 @@ jobs:
               echo 'CLI help generation is not yet implemented.'
               echo ''
               echo 'Check back soon or [contribute to the project]({{< ref "/contributing" >}}) to help add this feature!'
-            } > content/cli-reference/index.md
+            } > docs/cli-reference/index.md
             echo "✅ CLI reference placeholder created"
           fi
 


### PR DESCRIPTION
## Problem
The GitHub Pages workflow was failing during the build step because it was looking for a `content` folder, but Hugo is configured to use the `docs` folder as the content directory.

## Root Cause
- Hugo config (`config/_default/hugo.toml`) specifies `contentDir = "docs"`
- Workflow was still referencing the default `content` folder in multiple places
- Workflow was monitoring `hugo.toml` instead of the actual config location

## Solution
This PR updates the GitHub Pages workflow to align with the actual Hugo configuration:

### Changes Made
- **Workflow triggers**: Changed from `content/**` to `docs/**` to monitor the correct documentation folder
- **Config monitoring**: Updated from `hugo.toml` to `config/_default/hugo.toml` to watch the actual config file location
- **Content verification**: Modified verification step to check for `docs` directory instead of `content`
- **CLI docs generation**: Updated output path from `content/cli-reference/` to `docs/cli-reference/`

### Files Changed
- `.github/workflows/pages.yml`

## Testing
- [ ] Workflow should now trigger on changes to the `docs/` folder
- [ ] Build step should pass content structure verification
- [ ] CLI documentation should generate in the correct location
- [ ] Hugo build should complete successfully

## Impact
- ✅ Fixes failing GitHub Pages deployments
- ✅ Ensures documentation updates in `docs/` folder trigger deployments
- ✅ Aligns workflow with actual Hugo configuration
- ✅ No breaking changes to existing documentation structure
